### PR TITLE
Implement format on save

### DIFF
--- a/keymaps/rubyfmt.json
+++ b/keymaps/rubyfmt.json
@@ -1,8 +1,8 @@
 {
-    ".platform-darwin atom-text-editor[data-grammar='source ruby']": {
+    ".platform-darwin atom-text-editor[data-grammar^='source ruby']": {
       "cmd-;": "rubyfmt:formatBuffer"
   },
-  ".platform-win32 atom-text-editor[data-grammar='source ruby'], .platform-linux atom-text-editor[data-grammar='source ruby']": {
+  ".platform-win32 atom-text-editor[data-grammar^='source ruby'], .platform-linux atom-text-editor[data-grammar^='source ruby']": {
     "alt-;": "rubyfmt:formatBuffer"
   }
 }

--- a/lib/rubyfmt.js
+++ b/lib/rubyfmt.js
@@ -6,32 +6,73 @@ import { spawn } from 'child_process';
 export default {
 
   subscriptions: null,
+  config: {
+    formatOnSave: {
+      order: 1,
+      title: 'Format on save',
+      description: "Automatically format when saving",
+      type: 'boolean',
+      default: false
+    },
+    rubyExecutable: {
+      order: 2,
+      type: 'string',
+      default: 'ruby',
+      title: "Ruby executable",
+      description: "Can be overriden with an absolute path"
+    },
+    rubyfmtExecutable: {
+      order: 3,
+      type: 'string',
+      default: 'rubyfmt',
+      title: "Rubyfmt executable",
+      description: "Can be overriden with an absolute path"
+    },
+  },
 
   activate(state) {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.commands.add('atom-text-editor', {
-      'rubyfmt:formatBuffer': () => this.formatBuffer()
+      'rubyfmt:formatBuffer': () => this.handleManualFormat()
     }));
+    this.subscriptions.add(atom.workspace.observeTextEditors(textEditor => {
+      buffer = textEditor.getBuffer()
+      this.subscriptions.add(buffer.onWillSave(() => this.handleSave(textEditor)))
+    }))
   },
 
   deactivate() {
     this.subscriptions.dispose();
   },
 
-  formatBuffer() {
-    activePaneItem = atom.workspace.getActivePaneItem();
-    if(activePaneItem.getText) {
-      text = activePaneItem.getText()
-      this.format(text).then((formattedText) => {
-        activePaneItem.setText(formattedText);
-      });
+  handleManualFormat() {
+    item = atom.workspace.getActivePaneItem()
+    if(item.getBuffer) {
+      this.formatEditor(item);
     }
+  },
+
+  handleSave(textEditor) {
+    if(this.isRuby(textEditor) && atom.config.get('rubyfmt.formatOnSave')) { this.formatEditor(textEditor) }
+  },
+
+  isRuby(textEditor) {
+    return textEditor.getRootScopeDescriptor().getScopesArray().some(scope => {
+      return scope.startsWith("source.ruby")
+    })
+  },
+
+  formatEditor(textEditor) {
+    return this.format(textEditor.getText()).then((formattedText) => {
+      textEditor.setText(formattedText);
+    });
   },
 
   format(text) {
     var promise = new Promise(function(resolve, reject) {
       var toReturn
-      rubyfmt = spawn('rubyfmt', [], {windowsHide: true})
+      executable = atom.config.get('rubyfmt.rubyfmtExecutable')
+      rubyfmt = spawn(executable, [], {windowsHide: true})
       rubyfmt.stdout.on('data', (data) => {
         toReturn = data.toString('utf8');
       });
@@ -42,8 +83,12 @@ export default {
 
       rubyfmt.stdin.write(text);
       rubyfmt.stdin.end();
-      rubyfmt.on('close', () => {
-        resolve(toReturn);
+      rubyfmt.on('close', (status) => {
+        if(status == 0) {
+          resolve(toReturn);
+        } else {
+          reject(status)
+        }
       });
     });
     return promise;

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "rubyfmt",
   "main": "./lib/rubyfmt",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Atom package to autoformat Ruby code with Rubyfmt",
   "keywords": [
     "formatter",
+
+
     "format",
     "ruby",
     "rubyfmt"
   ],
-  "activationCommands": {
-    "atom-workspace": "rubyfmt:formatBuffer"
-  },
+  "activationHooks": ["language-ruby:grammar-used", "language-ruby-on-rails:grammar-used"],
   "repository": "https://github.com/toreriklinnerud/atom-rubyfmt",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Implements https://github.com/toreriklinnerud/atom-rubyfmt/issues/1 

Unfortunately there doesn't seem to be a unified way to see if we're dealing with a Ruby file. Package activation is contingent on the Ruby or RoR package being loaded. The keyboard shortcut is done by CSS selectors on the file grammar. And finally the on save check is a plain JS conditional.